### PR TITLE
Download by Episode or by Season

### DIFF
--- a/bin/by-episode.sh
+++ b/bin/by-episode.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Before continuing this script, let's ask the user what episode
+# they wish to download
+
+echo "Enter the season you wish to download episode from (ex: 01, 02, etc...)"
+read season
+echo
+echo "Enter the episode you wish to download from desired season (ex: 01, 02, etc..)."
+read episodenumber
+echo
+echo
+echo "You have chosen Season $season Episode $episodenumber. Press enter to continue."
+read enter
+echo
+echo
+# Now we take the user input and cat the season list containing
+# the episode. Also, a destination needs to be set.
+EPISODE_LIST="../episodes.list.d/season$season.list"
+DWNDIR="../download"
+
+mkdir -p $DWNDIR
+
+# Rather than download all episodes within the list file, 
+# let's pick out the episode we want from the list.
+
+# Due to pattern changes between seasons 1-4,
+# an if statement will be needed to reflect those patterns 
+# so the right episode is picked from the list.
+
+if [ $season == '01' ]
+# In season 1, there are no leading zeros, so we'll remove them before searching
+# for the episode in the list.
+then
+    episodenumber=$(echo $episodenumber|sed 's/^0*//') # Remove leading zero
+    EPISODE=$(sed -n "/\<ep$episodenumber\>/p" $EPISODE_LIST) 
+
+elif [[ $season == '02' || $season == '03' ]]
+then
+    EPISODE=$(sed -n  "/$seasonx$episodenumber/p" $EPISODE_LIST) 
+
+else
+    EPISODE=$(sed -n "/$season$episodenumber/p" $EPISODE_LIST) 
+
+fi
+
+# Once we have the episode chosen, now we can download it using wget. Yay!
+wget -c --directory-prefix=$DWNDIR $EPISODE
+
+#find $EPISODE_LISTS -type f | read -r EPLIST
+
+#do
+#	wget -c --directory-prefix=$DWNDIR --input-file=$EPLIST
+#done

--- a/bin/by-season.sh
+++ b/bin/by-season.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+echo "Enter the season you wish to download (ex: 01, 02, etc..)."
+read season
+
+echo "You have chosen season $season. Press enter to continue."
+read enter
+
+EPISODE_LISTS="../episodes.list.d/season$season.list"
+DWNDIR="../download"
+
+mkdir $DWNDIR
+
+find $EPISODE_LISTS -type f | while read -r EPLIST
+do
+	wget -c --directory-prefix=$DWNDIR --input-file=$EPLIST
+done


### PR DESCRIPTION
While cloning this repository, I noticed that a person could download the latest episode or download all episodes from all seasons. I didn't find an option to download a particular episode, nor did I see an option to download by season. So I figured, why not? I read through the code already written and added more features. Now a person can download a episode they missed or favored, as well as seasons. 

TODO: Add Season 13 and fix the 502 gateway error when attempting to download seasons 1, 2 and 3 after using the --no-check-certificate option (otherwise, wget won't be able to download due to being incapable of verifying certificate).